### PR TITLE
Add React marketplace skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# AI Agent Marketplace
+
+This is a simple React-based foundation for an AI Agent Marketplace. It uses **Vite** with **React Router** and the Context API for global state. Components and layouts are organized for reusability.
+
+## Scripts
+
+- `npm run dev` – Start the development server
+- `npm run build` – Build for production
+- `npm run preview` – Preview the production build
+
+## Project Structure
+
+```
+/src
+  /components    # Reusable UI components
+  /layouts       # Page wrappers
+  /pages         # Marketplace pages
+  /data          # Mock agent data
+  /context       # App-wide state
+  /styles        # Global styles
+  App.jsx        # Main app entry
+  main.jsx       # ReactDOM render
+```
+
+## Mock Data
+
+The `src/data/agents.js` file contains a simple list of agents used for the demo.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Agent Marketplace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ai-agent-marketplace",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,21 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import AgentDetail from './pages/AgentDetail';
+import { MarketplaceLayout } from './layouts/MarketplaceLayout';
+import { useAppContext } from './context/AppContext';
+
+function App() {
+  const { darkMode } = useAppContext();
+  return (
+    <div className={darkMode ? 'dark-mode' : ''}>
+      <MarketplaceLayout>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/agent/:agentId" element={<AgentDetail />} />
+        </Routes>
+      </MarketplaceLayout>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import Tag from './Tag';
+
+export default function AgentCard({ agent }) {
+  return (
+    <div className="border rounded p-4 shadow hover:shadow-md transition">
+      <img src={agent.avatarUrl} alt={agent.name} className="w-16 h-16 rounded-full" />
+      <h3 className="text-lg font-bold mt-2">{agent.name}</h3>
+      <p className="text-sm text-gray-700 mt-1">{agent.description}</p>
+      <div className="flex flex-wrap mt-2 gap-1">
+        {agent.tags.map((tag) => (
+          <Tag key={tag}>{tag}</Tag>
+        ))}
+      </div>
+      <Link to={`/agent/${agent.id}`} className="text-blue-600 mt-2 inline-block">
+        View Details
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,10 @@
+export default function Button({ children, onClick, className = '' }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 text-gray-600 p-4 text-center">
+      &copy; {new Date().getFullYear()} AI Agent Marketplace
+    </footer>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,9 @@
+import { Link } from 'react-router-dom';
+
+export default function Header() {
+  return (
+    <header className="bg-gray-800 text-white p-4 flex justify-between items-center">
+      <Link to="/" className="text-xl font-bold">AI Agent Marketplace</Link>
+    </header>
+  );
+}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,15 @@
+import Button from './Button';
+
+export default function Modal({ title, children, onClose }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-6 w-96 shadow-lg">
+        <h2 className="text-xl font-bold mb-4">{title}</h2>
+        <div className="mb-4">{children}</div>
+        <div className="text-right">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,0 +1,17 @@
+import Button from './Button';
+import { useAppContext } from '../context/AppContext';
+
+export default function SettingsPanel() {
+  const { darkMode, setDarkMode } = useAppContext();
+  return (
+    <div className="border p-4 rounded shadow bg-white mb-4">
+      <h3 className="font-bold mb-2">Settings</h3>
+      <div className="flex items-center gap-2">
+        <span>Dark Mode</span>
+        <Button onClick={() => setDarkMode(!darkMode)}>
+          {darkMode ? 'Disable' : 'Enable'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -1,0 +1,7 @@
+export default function Tag({ children }) {
+  return (
+    <span className="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs">
+      {children}
+    </span>
+  );
+}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useState, useContext } from 'react';
+
+const AppContext = createContext();
+
+export function AppProvider({ children }) {
+  const [darkMode, setDarkMode] = useState(false);
+  return (
+    <AppContext.Provider value={{ darkMode, setDarkMode }}>
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+export function useAppContext() {
+  return useContext(AppContext);
+}

--- a/src/data/agents.js
+++ b/src/data/agents.js
@@ -1,0 +1,28 @@
+const agents = [
+  {
+    id: 'chat-gpt',
+    name: 'ChatGPT',
+    description: 'Conversational AI agent for text-based interactions.',
+    avatarUrl: 'https://placehold.co/100x100',
+    tags: ['chat', 'nlp'],
+    interactionType: 'chat',
+  },
+  {
+    id: 'image-gen',
+    name: 'Image Generator',
+    description: 'Generates images based on textual prompts.',
+    avatarUrl: 'https://placehold.co/100x100',
+    tags: ['image', 'generation'],
+    interactionType: 'image',
+  },
+  {
+    id: 'voice-bot',
+    name: 'Voice Assistant',
+    description: 'Assists with voice commands and responses.',
+    avatarUrl: 'https://placehold.co/100x100',
+    tags: ['voice', 'assistant'],
+    interactionType: 'voice',
+  },
+];
+
+export default agents;

--- a/src/hooks/useAgents.js
+++ b/src/hooks/useAgents.js
@@ -1,0 +1,5 @@
+import agents from '../data/agents';
+
+export function useAgents() {
+  return agents;
+}

--- a/src/layouts/AgentDetailLayout.jsx
+++ b/src/layouts/AgentDetailLayout.jsx
@@ -1,0 +1,16 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import { Link } from 'react-router-dom';
+
+export function AgentDetailLayout({ children }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto p-4">
+        <Link to="/" className="text-blue-600 mb-4 inline-block">&larr; Back to Marketplace</Link>
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/layouts/MarketplaceLayout.jsx
+++ b/src/layouts/MarketplaceLayout.jsx
@@ -1,0 +1,12 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export function MarketplaceLayout({ children }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto p-4">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AppProvider } from './context/AppContext';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AppProvider>
+        <App />
+      </AppProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/AgentDetail.jsx
+++ b/src/pages/AgentDetail.jsx
@@ -1,0 +1,39 @@
+import { useParams } from 'react-router-dom';
+import agents from '../data/agents';
+import { AgentDetailLayout } from '../layouts/AgentDetailLayout';
+import Tag from '../components/Tag';
+import Button from '../components/Button';
+import { useState } from 'react';
+import Modal from '../components/Modal';
+
+export default function AgentDetail() {
+  const { agentId } = useParams();
+  const agent = agents.find((a) => a.id === agentId);
+  const [showModal, setShowModal] = useState(false);
+
+  if (!agent) {
+    return <p>Agent not found</p>;
+  }
+
+  return (
+    <AgentDetailLayout>
+      <div className="flex flex-col items-start">
+        <img src={agent.avatarUrl} alt={agent.name} className="w-32 h-32 rounded-full" />
+        <h2 className="text-2xl font-bold mt-4">{agent.name}</h2>
+        <p className="mt-2 text-gray-700">{agent.description}</p>
+        <div className="flex flex-wrap mt-2 gap-1">
+          {agent.tags.map((tag) => (
+            <Tag key={tag}>{tag}</Tag>
+          ))}
+        </div>
+        <Button onClick={() => setShowModal(true)} className="mt-4">Interact</Button>
+        {showModal && (
+          <Modal title={`Interact with ${agent.name}`} onClose={() => setShowModal(false)}>
+            <p>Interaction type: {agent.interactionType}</p>
+            <p className="text-sm mt-2 text-gray-500">Future interaction UI will go here.</p>
+          </Modal>
+        )}
+      </div>
+    </AgentDetailLayout>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,17 @@
+import AgentCard from '../components/AgentCard';
+import { useAgents } from '../hooks/useAgents';
+import SettingsPanel from '../components/SettingsPanel';
+
+export default function Home() {
+  const agents = useAgents();
+  return (
+    <div>
+      <SettingsPanel />
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        {agents.map((agent) => (
+          <AgentCard key={agent.id} agent={agent} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+
+.dark-mode {
+  background-color: #1a202c;
+  color: #fff;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up Vite React project skeleton
- add global context with simple dark mode toggle
- implement layouts and reusable components
- create Home and AgentDetail pages using mock data
- provide basic README

## Testing
- `npm run build` *(fails: vite not found)*